### PR TITLE
Ros2 cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(astra_camera)
 if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(astra_camera)
 if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
 endif()
 
 find_package(ament_cmake REQUIRED)
@@ -33,10 +33,6 @@ include_directories(include
                     )
 
 macro(targets)
-  if(NOT target_suffix STREQUAL "")
-    get_rclcpp_information("${rmw_implementation}" "rclcpp${target_suffix}")
-  endif()
-
   add_library(astra_wrapper${target_suffix}
      src/astra_convert.cpp
      src/astra_device.cpp
@@ -61,7 +57,7 @@ macro(targets)
     "sensor_msgs")
   target_link_libraries(astra_driver_lib${target_suffix} astra_wrapper${target_suffix} ${Boost_LIBRARIES})
   add_dependencies(astra_driver_lib${target_suffix} astra_openni2)
-  
+
   add_executable(astra_camera_node${target_suffix}
      ros/astra_camera_node.cpp
   )
@@ -73,7 +69,11 @@ macro(targets)
   )
 endmacro()
 
-call_for_each_rmw_implementation(targets GENERATE_DEFAULT)
+# For whatever reason when I enable this along with Connext, it fails to
+# link.  Disable for now.
+#call_for_each_rmw_implementation(targets GENERATE_DEFAULT)
+
+targets()
 
 install(FILES ${CMAKE_BINARY_DIR}/openni2/Redist/libOpenNI2Orbbec.so
   DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,48 +32,40 @@ include_directories(include
                     ${CMAKE_CURRENT_BINARY_DIR}/openni2/include
                     )
 
-macro(targets)
-  add_library(astra_wrapper${target_suffix}
-     src/astra_convert.cpp
-     src/astra_device.cpp
-     src/astra_device_info.cpp
-     src/astra_timer_filter.cpp
-     src/astra_frame_listener.cpp
-     src/astra_device_manager.cpp
-     src/astra_exception.cpp
-     src/astra_video_mode.cpp
-  )
-  ament_target_dependencies(astra_wrapper${target_suffix}
-    "rclcpp${target_suffix}"
-    "builtin_interfaces"
-    "sensor_msgs")
-  target_link_libraries(astra_wrapper${target_suffix} -lOpenNI2Orbbec ${Boost_LIBRARIES})
-  add_dependencies(astra_wrapper${target_suffix} astra_openni2)
+add_library(astra_wrapper
+   src/astra_convert.cpp
+   src/astra_device.cpp
+   src/astra_device_info.cpp
+   src/astra_timer_filter.cpp
+   src/astra_frame_listener.cpp
+   src/astra_device_manager.cpp
+   src/astra_exception.cpp
+   src/astra_video_mode.cpp
+)
+ament_target_dependencies(astra_wrapper
+  "rclcpp"
+  "builtin_interfaces"
+  "sensor_msgs")
+target_link_libraries(astra_wrapper -lOpenNI2Orbbec ${Boost_LIBRARIES})
+add_dependencies(astra_wrapper astra_openni2)
 
-  add_library(astra_driver_lib${target_suffix} src/astra_driver.cpp)
-  ament_target_dependencies(astra_driver_lib${target_suffix}
-    "rclcpp${target_suffix}"
-    "builtin_interfaces"
-    "sensor_msgs")
-  target_link_libraries(astra_driver_lib${target_suffix} astra_wrapper${target_suffix} ${Boost_LIBRARIES})
-  add_dependencies(astra_driver_lib${target_suffix} astra_openni2)
+add_library(astra_driver_lib src/astra_driver.cpp)
+ament_target_dependencies(astra_driver_lib
+  "rclcpp"
+  "builtin_interfaces"
+  "sensor_msgs")
+target_link_libraries(astra_driver_lib astra_wrapper ${Boost_LIBRARIES})
+add_dependencies(astra_driver_lib astra_openni2)
 
-  add_executable(astra_camera_node${target_suffix}
-     ros/astra_camera_node.cpp
-  )
-  target_link_libraries(astra_camera_node${target_suffix} astra_driver_lib${target_suffix})
-  add_dependencies(astra_camera_node${target_suffix} astra_openni2)
+add_executable(astra_camera_node
+   ros/astra_camera_node.cpp
+)
+target_link_libraries(astra_camera_node astra_driver_lib)
+add_dependencies(astra_camera_node astra_openni2)
 
-  install(TARGETS astra_camera_node${target_suffix}
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/
-  )
-endmacro()
-
-# For whatever reason when I enable this along with Connext, it fails to
-# link.  Disable for now.
-#call_for_each_rmw_implementation(targets GENERATE_DEFAULT)
-
-targets()
+install(TARGETS astra_camera_node
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/
+)
 
 install(FILES ${CMAKE_BINARY_DIR}/openni2/Redist/libOpenNI2Orbbec.so
   DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -75,8 +75,8 @@ private:
   //typedef astra_camera::AstraConfig Config;
   //typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
 
-  //void newIRFrameCallback(sensor_msgs::msg::Image::SharedPtr image);
-  //void newColorFrameCallback(sensor_msgs::msg::Image::SharedPtr image);
+  void newIRFrameCallback(sensor_msgs::msg::Image::SharedPtr image);
+  void newColorFrameCallback(sensor_msgs::msg::Image::SharedPtr image);
   void newDepthFrameCallback(sensor_msgs::msg::Image::SharedPtr image);
 
   // Methods to get calibration parameters for the various cameras
@@ -93,9 +93,9 @@ private:
 
   void advertiseROSTopics();
 
-  //void colorConnectCb();
+  void colorConnectCb();
   void depthConnectCb();
-  //void irConnectCb();
+  void irConnectCb();
 
   //bool getSerialCb(astra_camera::GetSerialRequest& req, astra_camera::GetSerialResponse& res);
 
@@ -132,6 +132,8 @@ private:
   //image_transport::CameraPublisher pub_color_;
   //image_transport::CameraPublisher pub_depth_;
   rclcpp::publisher::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_depth_raw_;
+  rclcpp::publisher::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_color_;
+  rclcpp::publisher::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_ir_;
   //image_transport::CameraPublisher pub_depth_raw_;
   //image_transport::CameraPublisher pub_ir_;
   //ros::Publisher pub_projector_info_;

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -106,21 +106,23 @@ void AstraDriver::advertiseROSTopics()
   boost::lock_guard<boost::mutex> lock(connect_mutex_);
 
   // Asus Xtion PRO does not have an RGB camera
-/*
   if (device_->hasColorSensor())
   {
-    image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::colorConnectCb, this);
-    ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::colorConnectCb, this);
-    pub_color_ = color_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
+    //image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::colorConnectCb, this);
+    //ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::colorConnectCb, this);
+    //pub_color_ = color_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
+    pub_color_ = nh_->create_publisher<sensor_msgs::msg::Image>("image", rmw_qos_profile_sensor_data);
+    this->colorConnectCb();
   }
 
   if (device_->hasIRSensor())
   {
-    image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::irConnectCb, this);
-    ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::irConnectCb, this);
-    pub_ir_ = ir_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
+    //image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::irConnectCb, this);
+    //ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::irConnectCb, this);
+    //pub_ir_ = ir_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
+    pub_ir_ = nh_->create_publisher<sensor_msgs::msg::Image>("ir_image", rmw_qos_profile_sensor_data);
+    this->irConnectCb();
   }
-*/
 
   if (device_->hasDepthSensor())
   {
@@ -324,14 +326,14 @@ void AstraDriver::applyConfigToOpenNIDevice()
 }
 */
 
-/*
 void AstraDriver::colorConnectCb()
 {
-  boost::lock_guard<boost::mutex> lock(connect_mutex_);
+  //boost::lock_guard<boost::mutex> lock(connect_mutex_);
 
-  color_subscribers_ = pub_color_.getNumSubscribers() > 0;
+  //color_subscribers_ = pub_color_.getNumSubscribers() > 0;
 
-  if (color_subscribers_ && !device_->isColorStreamStarted())
+  //if (color_subscribers_ && !device_->isColorStreamStarted())
+  if (!device_->isIRStreamStarted())
   {
     // Can't stream IR and RGB at the same time. Give RGB preference.
     if (device_->isIRStreamStarted())
@@ -347,14 +349,16 @@ void AstraDriver::colorConnectCb()
     device_->startColorStream();
 
   }
-  else if (!color_subscribers_ && device_->isColorStreamStarted())
+  //else if (!color_subscribers_ && device_->isColorStreamStarted())
+  else if (device_->isColorStreamStarted())
   {
     ROS_INFO("Stopping color stream.");
     device_->stopColorStream();
 
     // Start IR if it's been blocked on RGB subscribers
-    bool need_ir = pub_ir_.getNumSubscribers() > 0;
-    if (need_ir && !device_->isIRStreamStarted())
+    //bool need_ir = pub_ir_.getNumSubscribers() > 0;
+    //if (need_ir && !device_->isIRStreamStarted())
+    if (!device_->isIRStreamStarted())
     {
       device_->setIRFrameCallback(boost::bind(&AstraDriver::newIRFrameCallback, this, _1));
 
@@ -363,7 +367,6 @@ void AstraDriver::colorConnectCb()
     }
   }
 }
-*/
 
 void AstraDriver::depthConnectCb()
 {
@@ -390,14 +393,14 @@ void AstraDriver::depthConnectCb()
   }
 }
 
-/*
 void AstraDriver::irConnectCb()
 {
-  boost::lock_guard<boost::mutex> lock(connect_mutex_);
+  //boost::lock_guard<boost::mutex> lock(connect_mutex_);
 
-  ir_subscribers_ = pub_ir_.getNumSubscribers() > 0;
+  //ir_subscribers_ = pub_ir_.getNumSubscribers() > 0;
 
-  if (ir_subscribers_ && !device_->isIRStreamStarted())
+  //if (ir_subscribers_ && !device_->isIRStreamStarted())
+  if (!device_->isIRStreamStarted())
   {
     // Can't stream IR and RGB at the same time
     if (device_->isColorStreamStarted())
@@ -412,47 +415,47 @@ void AstraDriver::irConnectCb()
       device_->startIRStream();
     }
   }
-  else if (!ir_subscribers_ && device_->isIRStreamStarted())
+  //else if (!ir_subscribers_ && device_->isIRStreamStarted())
+  else if (device_->isIRStreamStarted())
   {
     ROS_INFO("Stopping IR stream.");
     device_->stopIRStream();
   }
 }
-*/
 
-/*
-void AstraDriver::newIRFrameCallback(sensor_msgs::ImagePtr image)
+void AstraDriver::newIRFrameCallback(sensor_msgs::msg::Image::SharedPtr image)
 {
-  if ((++data_skip_ir_counter_)%data_skip_==0)
+  //if ((++data_skip_ir_counter_)%data_skip_==0)
   {
     data_skip_ir_counter_ = 0;
 
-    if (ir_subscribers_)
+    //if (ir_subscribers_)
     {
       image->header.frame_id = ir_frame_id_;
-      image->header.stamp = image->header.stamp + ir_time_offset_;
+      //image->header.stamp = image->header.stamp + ir_time_offset_;
 
-      pub_ir_.publish(image, getIRCameraInfo(image->width, image->height, image->header.stamp));
+      //pub_ir_.publish(image, getIRCameraInfo(image->width, image->height, image->header.stamp));
+      pub_ir_->publish(image);
     }
   }
 }
 
-void AstraDriver::newColorFrameCallback(sensor_msgs::ImagePtr image)
+void AstraDriver::newColorFrameCallback(sensor_msgs::msg::Image::SharedPtr image)
 {
-  if ((++data_skip_color_counter_)%data_skip_==0)
+  //if ((++data_skip_color_counter_)%data_skip_==0)
   {
     data_skip_color_counter_ = 0;
 
-    if (color_subscribers_)
+    //if (color_subscribers_)
     {
       image->header.frame_id = color_frame_id_;
-      image->header.stamp = image->header.stamp + color_time_offset_;
+      //image->header.stamp = image->header.stamp + color_time_offset_;
 
-      pub_color_.publish(image, getColorCameraInfo(image->width, image->height, image->header.stamp));
+      //pub_color_.publish(image, getColorCameraInfo(image->width, image->height, image->header.stamp));
+      pub_color_->publish(image);
     }
   }
 }
-*/
 
 void AstraDriver::newDepthFrameCallback(sensor_msgs::msg::Image::SharedPtr image)
 {

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -659,10 +659,9 @@ std::string AstraDriver::resolveDeviceURI(const std::string& device_id) throw(As
   if (device_id.size() > 1 && device_id[0] == '#')
   {
     std::istringstream device_number_str(device_id.substr(1));
-    int device_number;
+    unsigned int device_number;
     device_number_str >> device_number;
-    int device_index = device_number - 1; // #1 refers to first device
-    if (device_index >= available_device_URIs->size() || device_index < 0)
+    if (device_number == 0 || device_number > available_device_URIs->size())
     {
       THROW_OPENNI_EXCEPTION(
           "Invalid device number %i, there are %zu devices connected.",
@@ -670,7 +669,7 @@ std::string AstraDriver::resolveDeviceURI(const std::string& device_id) throw(As
     }
     else
     {
-      return available_device_URIs->at(device_index);
+      return available_device_URIs->at(device_number - 1);  // #1 refers to first device
     }
   }
   // look for '<bus>@<number>' format

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -129,7 +129,7 @@ void AstraDriver::advertiseROSTopics()
     //ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::depthConnectCb, this);
     //pub_depth_raw_ = depth_it.advertiseCamera("image_raw", 1, itssc, itssc, rssc, rssc);
     //pub_depth_ = depth_raw_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
-    pub_depth_raw_ = nh_->create_publisher<sensor_msgs::msg::Image>("image", rmw_qos_profile_sensor_data);
+    pub_depth_raw_ = nh_->create_publisher<sensor_msgs::msg::Image>("depth", rmw_qos_profile_sensor_data);
     this->depthConnectCb();
   }
 

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -85,6 +85,11 @@ AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::S
 
 void AstraDriver::advertiseROSTopics()
 {
+  rmw_qos_profile_t custom_camera_qos_profile = rmw_qos_profile_default;
+
+  custom_camera_qos_profile.depth = 10;
+  custom_camera_qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  custom_camera_qos_profile.history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
 
   // Allow remapping namespaces rgb, ir, depth, depth_registered
 /*
@@ -111,7 +116,7 @@ void AstraDriver::advertiseROSTopics()
     //image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::colorConnectCb, this);
     //ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::colorConnectCb, this);
     //pub_color_ = color_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
-    pub_color_ = nh_->create_publisher<sensor_msgs::msg::Image>("image", rmw_qos_profile_sensor_data);
+    pub_color_ = nh_->create_publisher<sensor_msgs::msg::Image>("image", custom_camera_qos_profile);
     this->colorConnectCb();
   }
 
@@ -120,7 +125,7 @@ void AstraDriver::advertiseROSTopics()
     //image_transport::SubscriberStatusCallback itssc = boost::bind(&AstraDriver::irConnectCb, this);
     //ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::irConnectCb, this);
     //pub_ir_ = ir_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
-    pub_ir_ = nh_->create_publisher<sensor_msgs::msg::Image>("ir_image", rmw_qos_profile_sensor_data);
+    pub_ir_ = nh_->create_publisher<sensor_msgs::msg::Image>("ir_image", custom_camera_qos_profile);
     this->irConnectCb();
   }
 
@@ -131,7 +136,7 @@ void AstraDriver::advertiseROSTopics()
     //ros::SubscriberStatusCallback rssc = boost::bind(&AstraDriver::depthConnectCb, this);
     //pub_depth_raw_ = depth_it.advertiseCamera("image_raw", 1, itssc, itssc, rssc, rssc);
     //pub_depth_ = depth_raw_it.advertiseCamera("image", 1, itssc, itssc, rssc, rssc);
-    pub_depth_raw_ = nh_->create_publisher<sensor_msgs::msg::Image>("depth", rmw_qos_profile_sensor_data);
+    pub_depth_raw_ = nh_->create_publisher<sensor_msgs::msg::Image>("depth", custom_camera_qos_profile);
     this->depthConnectCb();
   }
 

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -473,16 +473,24 @@ void AstraDriver::newDepthFrameCallback(sensor_msgs::msg::Image::SharedPtr image
       {
         uint16_t* data = reinterpret_cast<uint16_t*>(&image->data[0]);
         for (unsigned int i = 0; i < image->width * image->height; ++i)
+        {
           if (data[i] != 0)
-                data[i] += z_offset_mm_;
+          {
+            data[i] += z_offset_mm_;
+          }
+        }
       }
 
       if (fabs(z_scaling_ - 1.0) > 1e-6)
       {
         uint16_t* data = reinterpret_cast<uint16_t*>(&image->data[0]);
         for (unsigned int i = 0; i < image->width * image->height; ++i)
+        {
           if (data[i] != 0)
-                data[i] = static_cast<uint16_t>(data[i] * z_scaling_);
+          {
+            data[i] = static_cast<uint16_t>(data[i] * z_scaling_);
+          }
+        }
       }
 
       sensor_msgs::msg::CameraInfo::SharedPtr cam_info;
@@ -491,7 +499,8 @@ void AstraDriver::newDepthFrameCallback(sensor_msgs::msg::Image::SharedPtr image
       {
         image->header.frame_id = color_frame_id_;
         cam_info = getColorCameraInfo(image->width,image->height, image->header.stamp);
-      } else
+      }
+      else
       {
         image->header.frame_id = depth_frame_id_;
         cam_info = getDepthCameraInfo(image->width,image->height, image->header.stamp);
@@ -912,7 +921,7 @@ int AstraDriver::lookupVideoModeFromDynConfig(int mode_nr, AstraVideoMode& video
 
   it = video_modes_lookup_.find(mode_nr);
 
-  if (it!=video_modes_lookup_.end())
+  if (it != video_modes_lookup_.end())
   {
     video_mode = it->second;
     ret = 0;
@@ -945,7 +954,8 @@ sensor_msgs::msg::Image::SharedPtr AstraDriver::rawToFloatingPointConversion(sen
     if (*in_ptr==0 || *in_ptr==0x7FF)
     {
       *out_ptr = bad_point;
-    } else
+    }
+    else
     {
       *out_ptr = static_cast<float>(*in_ptr)/1000.0f;
     }


### PR DESCRIPTION
This PR gets the astra camera working a bit better with ROS2.  In particular, it makes it compile again (though only against Fast-RTPS), it turns the color and IR camera code back on, and it publishes the depth data on a separate topic from color on a separate topic from IR.  Note that in order for this to really work well, you need to edit rmw_fastrtps/rmw_fastrtps_cpp/src/functions.cpp to make the heartbeat go every 10ms; see https://github.com/ros2/rmw_fastrtps/issues/81 for more information.