### PR TITLE
Add the ability to switch the camera mode on the Astra driver.

### DIFF
--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -69,7 +69,8 @@ class AstraDriver
 {
 public:
   //AstraDriver(ros::NodeHandle& n, ros::NodeHandle& pnh) ;
-  AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::SharedPtr& pnh, size_t width, size_t height, double framerate);
+  AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::SharedPtr& pnh, size_t width, size_t height, double framerate,
+              size_t dwidth, size_t dheight, double dframerate, PixelFormat dformat);
 
 private:
   //typedef astra_camera::AstraConfig Config;

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -69,7 +69,7 @@ class AstraDriver
 {
 public:
   //AstraDriver(ros::NodeHandle& n, ros::NodeHandle& pnh) ;
-  AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::SharedPtr& pnh) ;
+  AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::SharedPtr& pnh, size_t width, size_t height, double framerate);
 
 private:
   //typedef astra_camera::AstraConfig Config;

--- a/ros/astra_camera_node.cpp
+++ b/ros/astra_camera_node.cpp
@@ -32,13 +32,88 @@
 
 #include "astra_camera/astra_driver.h"
 
+static std::string get_command_option(const std::vector<std::string> &args, const std::string &option)
+{
+  auto it = std::find(args.begin(), args.end(), option);
+  if (it != args.end() && ++it != args.end()) {
+    return *it;
+  }
+  return std::string();
+}
+
+static void parse_command_options(int argc, char **argv, size_t *width, size_t *height,
+                                  double *framerate)
+{
+  std::vector<std::string> args(argv, argv + argc);
+
+  std::string width_str = get_command_option(args, "-w");
+  if (!width_str.empty()) {
+    *width = std::stoul(width_str.c_str());
+  }
+
+  std::string height_str = get_command_option(args, "-h");
+  if (!height_str.empty()) {
+    *height = std::stoul(height_str.c_str());
+  }
+
+  std::string framerate_str = get_command_option(args, "-f");
+  if (!framerate_str.empty()) {
+    *framerate = std::stod(framerate_str.c_str());
+  }
+}
+
+struct AllowedVal {
+  size_t width;
+  size_t height;
+  double framerate;
+};
+
 int main(int argc, char **argv){
+
+  // This list of allowed values comes from cfg/Astra.cfg
+  std::vector<AllowedVal> allowed{
+    AllowedVal{1280, 1024, 30},
+    AllowedVal{1280, 1024, 15},
+    AllowedVal{1280, 720, 30},
+    AllowedVal{1280, 720, 15},
+    AllowedVal{640, 480, 30},
+    AllowedVal{640, 480, 25},
+    AllowedVal{320, 240, 25},
+    AllowedVal{320, 240, 30},
+    AllowedVal{320, 240, 60},
+    AllowedVal{160, 120, 25},
+    AllowedVal{160, 120, 30},
+    AllowedVal{160, 120, 60},
+  };
+  size_t width = 1280;
+  size_t height = 1024;
+  double framerate = 30;
+
+  // TODO(clalancette): parsing the command-line options here is temporary until
+  // we get parameters working in ROS2.
+  parse_command_options(argc, argv, &width, &height, &framerate);
+
+  bool good_combo = false;
+  for (std::vector<AllowedVal>::iterator it = allowed.begin() ; it != allowed.end(); ++it) {
+    if (it->width == width && it->height == height && it->framerate == framerate) {
+      good_combo = true;
+      break;
+    }
+  }
+
+  if (!good_combo) {
+    std::cerr << "Invalid width/height/framerate combo; allowed combos are:" << std::endl;
+    for (std::vector<AllowedVal>::iterator it = allowed.begin() ; it != allowed.end(); ++it) {
+      std::cerr << "  " << it->width << "x" << it->height << "@" << it->framerate << "Hz" << std::endl;
+    }
+    return 1;
+  }
 
   rclcpp::init(argc, argv);
   rclcpp::node::Node::SharedPtr n = rclcpp::node::Node::make_shared("astra_camera");
   rclcpp::node::Node::SharedPtr pnh = rclcpp::node::Node::make_shared("astra_camera_");
 
-  astra_wrapper::AstraDriver drv(n, pnh);
+  astra_wrapper::AstraDriver drv(n, pnh, width, height, framerate);
 
   rclcpp::spin(n);
 

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -44,7 +44,7 @@
 namespace astra_wrapper
 {
 
-AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::SharedPtr& pnh, size_t width, size_t height, double framerate) :
+AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::SharedPtr& pnh, size_t width, size_t height, double framerate, size_t dwidth, size_t dheight, double dframerate, PixelFormat dformat) :
     nh_(n),
     pnh_(pnh),
     device_manager_(AstraDeviceManager::getSingelton()),
@@ -80,11 +80,12 @@ AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::S
   z_offset_mm_ = 0;
 
   AstraVideoMode color_video_mode{width, height, framerate, PIXEL_FORMAT_RGB888};
-
   setColorVideoMode(color_video_mode);
 
-  advertiseROSTopics();
+  AstraVideoMode depth_video_mode{dwidth, dheight, dframerate, dformat};
+  setDepthVideoMode(depth_video_mode);
 
+  advertiseROSTopics();
 }
 
 void AstraDriver::advertiseROSTopics()

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -44,7 +44,7 @@
 namespace astra_wrapper
 {
 
-AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::SharedPtr& pnh) :
+AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::SharedPtr& pnh, size_t width, size_t height, double framerate) :
     nh_(n),
     pnh_(pnh),
     device_manager_(AstraDeviceManager::getSingelton()),
@@ -78,6 +78,10 @@ AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::S
 */
   z_scaling_ = 1.0;
   z_offset_mm_ = 0;
+
+  AstraVideoMode color_video_mode{width, height, framerate, PIXEL_FORMAT_RGB888};
+
+  setColorVideoMode(color_video_mode);
 
   advertiseROSTopics();
 


### PR DESCRIPTION
Until we have proper parameters in ROS2, this allows us to switch the camera mode on the command-line.  Note that not all combinations are supported by all cameras, so any particular mode may or may not work depending on which Astra camera you have.  Once we have full parameter support, this hack can be removed.