### PR TITLE
check return value to quash warning

### DIFF
--- a/src/astra_frame_listener.cpp
+++ b/src/astra_frame_listener.cpp
@@ -73,7 +73,10 @@ void AstraFrameListener::onNewFrame(openni::VideoStream& stream)
 
     //ros::Time ros_now = ros::Time::now();
     rcl_time_point_value_t ros_now;
-    rcl_system_time_now(&ros_now);
+    if (rcl_system_time_now(&ros_now) != RCL_RET_OK)
+    {
+      ROS_ERROR("Failed to get current time");
+    }
 
     if (!user_device_timer_)
     {

--- a/src/astra_frame_listener.cpp
+++ b/src/astra_frame_listener.cpp
@@ -75,7 +75,8 @@ void AstraFrameListener::onNewFrame(openni::VideoStream& stream)
     rcl_time_point_value_t ros_now;
     if (rcl_system_time_now(&ros_now) != RCL_RET_OK)
     {
-      ROS_ERROR("Failed to get current time");
+      ROS_ERROR("Failed to get current time; ignoring frame");
+      return;
     }
 
     if (!user_device_timer_)


### PR DESCRIPTION
Fix this warning by checking a return value:

http://ci.ros2.org/job/ci_turtlebot-demo/20/warnings22Result/new/NORMAL/

I verified locally that the warning is removed. Otherwise the code is the same as what was built and tested in http://ci.ros2.org/job/ci_turtlebot-demo/20, so I won't run new CI.