### PR TITLE
Switch to using rcutils_system_time_now.

### DIFF
--- a/src/astra_frame_listener.cpp
+++ b/src/astra_frame_listener.cpp
@@ -68,8 +68,8 @@ void AstraFrameListener::onNewFrame(openni::VideoStream& stream)
     sensor_msgs::msg::Image::SharedPtr image(new sensor_msgs::msg::Image);
 
     //ros::Time ros_now = ros::Time::now();
-    rcl_time_point_value_t ros_now;
-    if (rcl_system_time_now(&ros_now) != RCL_RET_OK)
+    rcutils_time_point_value_t ros_now;
+    if (rcutils_system_time_now(&ros_now) != RCUTILS_RET_OK)
     {
       ROS_ERROR("Failed to get current time; ignoring frame");
       return;


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#342

CI:
* TB2 Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux&build=22)](http://ci.ros2.org/job/ci_turtlebot-demo_linux/22/)
* TB2 Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_turtlebot-demo_linux-aarch64&build=38)](http://ci.ros2.org/job/ci_turtlebot-demo_linux-aarch64/38/)