### PR TITLE
Flag included in class initializer list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,4 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/
 )
 
-ament_export_libraries(astra_driver_lib)
-
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,4 +89,6 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/
 )
 
+ament_export_libraries(astra_driver_lib)
+
 ament_package()

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -54,6 +54,7 @@ AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::S
     pnh_(pnh),
     device_manager_(AstraDeviceManager::getSingelton()),
     config_init_(false),
+    depth_registration_(false),
     data_skip_ir_counter_(0),
     data_skip_color_counter_(0),
     data_skip_depth_counter_ (0),


### PR DESCRIPTION
The depth_registration_ flag was never initialized, but used during
execution, so the behavior was flaky since the value was unpredictable. 

fixes this issue #8 