### PR TITLE
Depend on git at build time.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,8 @@
 
   <maintainer email="liuhua@orbbec.com">Tim Liu</maintainer>
 
+  <build_depend>git</build_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>boost</depend>


### PR DESCRIPTION
On the ROS 2 [test farm](http://test.build.ros2.org/job/Rbin_uX64__astra_camera__ubuntu_xenial_amd64__binary/1/console#console-section-1) I ran into an issue with git being required at build time.

```
15:32:24 CMake Error at /usr/share/cmake-3.5/Modules/ExternalProject.cmake:1757 (message):
15:32:24   error: could not find git for clone of astra_openni2
15:32:24 Call Stack (most recent call first):
15:32:24   /usr/share/cmake-3.5/Modules/ExternalProject.cmake:2459 (_ep_add_download_command)
15:32:24   CMakeLists.txt:24 (ExternalProject_Add)
```