### PR TITLE
Add libusb-1.0 dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <depend>boost</depend>
   <depend>builtin_interfaces</depend>
+  <depend>libusb-1.0-dev</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
 


### PR DESCRIPTION
Cut another release with the git build dependency and it now appears that compilation of astra_openni2 needs libusb-1.0. I expect that if it needs it at build time it'll also need to be an exec depend but if not we can relax this to a build_depend.

Here's the [test farm build](http://test.build.ros2.org/job/Rbin_uX64__astra_camera__ubuntu_xenial_amd64__binary/3/console#console-section-1)

```
07:50:54 Linux/XnLinuxUSB.cpp:29:31: fatal error: libusb-1.0/libusb.h: No such file or directory
```