### PR TITLE
Depth registration settable by param

### DIFF
--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -65,7 +65,6 @@ AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::S
 {
 
   genVideoModeTableMap();
-
   readConfigFromParameterServer();
 
 #if MULTI_ASTRA
@@ -750,6 +749,14 @@ void AstraDriver::readConfigFromParameterServer()
   pnh_.param("depth_camera_info_url", ir_info_url_, std::string());
 */
 
+  // TODO: ultimately, this should probably be handled by dynamic reconfigure
+  //   in the methods such as applyConfigToOpenNIDevice(), but for now, we
+  //   just want to read the initial state from the parameter server.
+  pnh_->get_parameter("depth_registration", depth_registration_);
+  if(depth_registration_)
+  {
+    std::cout << "Astra depth registration enabled" << std::endl;
+  }
 }
 
 std::string AstraDriver::resolveDeviceURI(const std::string& device_id) throw(AstraException)

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -65,6 +65,7 @@ AstraDriver::AstraDriver(rclcpp::node::Node::SharedPtr& n, rclcpp::node::Node::S
 {
 
   genVideoModeTableMap();
+
   readConfigFromParameterServer();
 
 #if MULTI_ASTRA

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -728,6 +728,15 @@ sensor_msgs::msg::CameraInfo::SharedPtr AstraDriver::getDepthCameraInfo(int widt
 void AstraDriver::readConfigFromParameterServer()
 {
   depth_frame_id_ = std::string("openni_depth_optical_frame");
+
+  // Load the depth registration parameter, which may have been set before
+  //   driver initialization.
+  pnh_->get_parameter("depth_registration", depth_registration_);
+  if(depth_registration_)
+  {
+    std::cout << "Astra depth registration enabled" << std::endl;
+  }
+
 // TODO
 /*
   if (!pnh_.getParam("device_id", device_id_))
@@ -749,14 +758,6 @@ void AstraDriver::readConfigFromParameterServer()
   pnh_.param("depth_camera_info_url", ir_info_url_, std::string());
 */
 
-  // TODO: ultimately, this should probably be handled by dynamic reconfigure
-  //   in the methods such as applyConfigToOpenNIDevice(), but for now, we
-  //   just want to read the initial state from the parameter server.
-  pnh_->get_parameter("depth_registration", depth_registration_);
-  if(depth_registration_)
-  {
-    std::cout << "Astra depth registration enabled" << std::endl;
-  }
 }
 
 std::string AstraDriver::resolveDeviceURI(const std::string& device_id) throw(AstraException)

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -734,7 +734,7 @@ void AstraDriver::readConfigFromParameterServer()
   pnh_->get_parameter("depth_registration", depth_registration_);
   if(depth_registration_)
   {
-    std::cout << "Astra depth registration enabled" << std::endl;
+    ROS_INFO("Astra depth registration enabled");
   }
 
 // TODO


### PR DESCRIPTION
Setting the `depth_registration` param on the Astra's private node handle will now be respected. The default behavior remains the same (`depth_registration_ = false`). At some point we should do the rest of the params, but this is the only one for which there is a current need.

example usage:
```
  rclcpp::node::Node::SharedPtr astra_node =
      rclcpp::node::Node::make_shared("astra_camera");
  rclcpp::node::Node::SharedPtr astra_private_node =
      rclcpp::node::Node::make_shared("astra_camera_");


  astra_private_node->set_parameter_if_not_set("depth_registration", true);


  astra_wrapper::AstraDriver drv(astra_node, astra_private_node,
    rgb_width, rgb_height, framerate,
    depth_width, depth_height, depth_framerate, depth_format);
```