### PR TITLE
Disable various channels with params

### DIFF
--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -98,6 +98,11 @@ private:
   void depthConnectCb();
   void irConnectCb();
 
+  /// Start the IR stream unless IR streaming is disabled. Because of the
+  ///   restriction on IR/RGB simultaneous streaming, IR streaming is initiated
+  ///   from multiple methods.
+  void irAttemptStream();
+
   //bool getSerialCb(astra_camera::GetSerialRequest& req, astra_camera::GetSerialResponse& res);
 
   //void configCb(Config &config, uint32_t level);
@@ -183,7 +188,14 @@ private:
   bool depth_subscribers_;
   bool depth_raw_subscribers_;
 
-  bool use_device_time_;
+  /// If false, then camera will never start an IR stream.
+  bool can_publish_ir_;
+  /// If false, then camera will never start a color stream.
+  bool can_publish_color_;
+  /// If false, then camera will never start a depth stream.
+  bool can_publish_depth_;
+
+  // bool use_device_time_;
 
   //Config old_config_;
 };

--- a/ros/astra_camera_node.cpp
+++ b/ros/astra_camera_node.cpp
@@ -41,6 +41,11 @@ static std::string get_command_option(const std::vector<std::string> &args, cons
   return std::string();
 }
 
+static bool get_command_option_exists(const std::vector<std::string> &args, const std::string &option)
+{
+  return std::find(args.begin(), args.end(), option) != args.end();
+}
+
 static bool parse_command_options(int argc, char **argv, size_t *width, size_t *height,
                                   double *framerate, size_t *depth_width, size_t *depth_height,
                                   double *depth_framerate, astra_wrapper::PixelFormat *dformat,
@@ -92,14 +97,9 @@ static bool parse_command_options(int argc, char **argv, size_t *width, size_t *
     }
   }
 
-  std::string no_ir_str = get_command_option(args, "-I");
-  *use_ir = no_ir_str.empty();
-
-  std::string no_color_str = get_command_option(args, "-C");
-  *use_color = no_color_str.empty();
-
-  std::string no_depth_str = get_command_option(args, "-D");
-  *use_depth = no_depth_str.empty();
+  *use_ir = !get_command_option_exists(args, "-I");
+  *use_color = !get_command_option_exists(args, "-C");
+  *use_depth = !get_command_option_exists(args, "-D");
 
   return true;
 }

--- a/ros/astra_camera_node.cpp
+++ b/ros/astra_camera_node.cpp
@@ -135,7 +135,6 @@ int main(int argc, char **argv){
   pnh->set_parameter_if_not_set("use_color", use_color);
   pnh->set_parameter_if_not_set("use_depth", use_depth);
 
-
   astra_wrapper::AstraDriver drv(n, pnh, width, height, framerate, dwidth, dheight, dframerate, dformat);
 
   rclcpp::spin(n);

--- a/ros/astra_camera_node.cpp
+++ b/ros/astra_camera_node.cpp
@@ -43,7 +43,8 @@ static std::string get_command_option(const std::vector<std::string> &args, cons
 
 static bool parse_command_options(int argc, char **argv, size_t *width, size_t *height,
                                   double *framerate, size_t *depth_width, size_t *depth_height,
-                                  double *depth_framerate, astra_wrapper::PixelFormat *dformat)
+                                  double *depth_framerate, astra_wrapper::PixelFormat *dformat,
+                                  bool *use_ir, bool *use_color, bool *use_depth)
 {
   std::vector<std::string> args(argv, argv + argc);
 
@@ -91,6 +92,15 @@ static bool parse_command_options(int argc, char **argv, size_t *width, size_t *
     }
   }
 
+  std::string no_ir_str = get_command_option(args, "-I");
+  *use_ir = no_ir_str.empty();
+
+  std::string no_color_str = get_command_option(args, "-C");
+  *use_color = no_color_str.empty();
+
+  std::string no_depth_str = get_command_option(args, "-D");
+  *use_depth = no_depth_str.empty();
+
   return true;
 }
 
@@ -107,15 +117,24 @@ int main(int argc, char **argv){
   double dframerate = 30;
   astra_wrapper::PixelFormat dformat = astra_wrapper::PixelFormat::PIXEL_FORMAT_DEPTH_1_MM;
 
+  bool use_ir = true;
+  bool use_color = true;
+  bool use_depth = true;
+
   // TODO(clalancette): parsing the command-line options here is temporary until
   // we get parameters working in ROS2.
-  if (!parse_command_options(argc, argv, &width, &height, &framerate, &dwidth, &dheight, &dframerate, &dformat)) {
+  if (!parse_command_options(argc, argv, &width, &height, &framerate, &dwidth, &dheight, &dframerate, &dformat, &use_ir, &use_color, &use_depth)) {
     return 1;
   }
 
   rclcpp::init(argc, argv);
   rclcpp::node::Node::SharedPtr n = rclcpp::node::Node::make_shared("astra_camera");
   rclcpp::node::Node::SharedPtr pnh = rclcpp::node::Node::make_shared("astra_camera_");
+
+  pnh->set_parameter_if_not_set("use_ir", use_ir);
+  pnh->set_parameter_if_not_set("use_color", use_color);
+  pnh->set_parameter_if_not_set("use_depth", use_depth);
+
 
   astra_wrapper::AstraDriver drv(n, pnh, width, height, framerate, dwidth, dheight, dframerate, dformat);
 

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -749,8 +749,9 @@ sensor_msgs::msg::CameraInfo::SharedPtr AstraDriver::getDepthCameraInfo(int widt
 
 void AstraDriver::readConfigFromParameterServer()
 {
-  // Load the depth registration parameter, which may have been set before
-  //   driver initialization.
+  depth_frame_id_ = std::string("openni_depth_optical_frame");
+
+  // Load channel disabling parameters
   pnh_->get_parameter("use_ir", can_publish_ir_);
   if(!can_publish_ir_)
   {
@@ -759,16 +760,13 @@ void AstraDriver::readConfigFromParameterServer()
   pnh_->get_parameter("use_color", can_publish_color_);
   if(!can_publish_color_)
   {
-    ROS_INFO("Astra rgb camera disabled");
+    ROS_INFO("Astra RGB camera disabled");
   }
   pnh_->get_parameter("use_depth", can_publish_depth_);
   if(!can_publish_depth_)
   {
     ROS_INFO("Astra depth camera disabled");
   }
-
-
-  depth_frame_id_ = std::string("openni_depth_optical_frame");
 
   // Load the depth registration parameter, which may have been set before
   //   driver initialization.

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -439,7 +439,7 @@ void AstraDriver::colorConnectCb()
     ROS_INFO("Stopping color stream.");
     device_->stopColorStream();
 
-    // TODO: With the IR subscriber check commented out, this section just
+    // TODO(Kukanani): With the IR subscriber check commented out, this section just
     // blindly starts streaming IR data when the RGB stream is shut down.
     // Start IR if it's been blocked on RGB subscribers
     //bool need_ir = pub_ir_.getNumSubscribers() > 0;


### PR DESCRIPTION
Allow disabling the use of RGB, IR, and/or depth by using the parameters passed to the Astra driver. The `astra_camera_node` also now supports toggling these parameters using the flags `-I`, `-C`, and `-D`.

Split the IR streaming code into another function to avoid code duplication.