### PR TITLE
add dummy git config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ ExternalProject_Add(astra_openni2
   # SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/astra_openni2/OpenNI2
   GIT_REPOSITORY https://github.com/orbbec/OpenNI2.git
   GIT_TAG orbbec_ros
+  GIT_CONFIG user.email=you@example.com user.name=YourName
   CONFIGURE_COMMAND echo "no need to configure"
   #${CMAKE_CURRENT_SOURCE_DIR}/libantlr/configure --prefix=<INSTALL_DIR>
   BUILD_IN_SOURCE 1


### PR DESCRIPTION
To be able to build the package on system that don't have a globe git config: http://build.ros2.org/view/Bbin_uB64/job/Bbin_uB64__astra_camera__ubuntu_bionic_amd64__binary/2/console